### PR TITLE
Add support for nested original error from downstream

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/openapi/problem/HttpProblem.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/problem/HttpProblem.java
@@ -78,9 +78,13 @@ public class HttpProblem extends RuntimeException {
     @Schema(description = "List of validation constraint violations that occurred")
     private List<Violation> errors;
 
+    /** Original cause of error */
+    @Schema(description = "Original cause of error")
+    private HttpProblem cause;
+
     public HttpProblem(HttpProblem problem) {
         this(problem.getType(), problem.getTitle(), problem.getStatus(), problem.getDetail(), problem.getInstance(),
-                problem.getContexts(), problem.getHeaders(), problem.getErrors());
+                problem.getContexts(), problem.getHeaders(), problem.getErrors(), problem.getCause());
     }
 
     public Response toResponse() {

--- a/runtime/src/main/java/io/quarkiverse/openapi/problem/jackson/JacksonProblemSerializer.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/problem/jackson/JacksonProblemSerializer.java
@@ -59,6 +59,11 @@ public final class JacksonProblemSerializer extends StdSerializer<HttpProblem> {
             json.writeObjectField("errors", problem.getErrors());
         }
 
+        // Write the cause element if present
+        if (problem.getCause() != null) {
+            json.writeObjectField("cause", problem.getCause());
+        }
+
         json.writeEndObject();
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/openapi/problem/jsonb/JsonbProblemSerializer.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/problem/jsonb/JsonbProblemSerializer.java
@@ -50,6 +50,12 @@ public final class JsonbProblemSerializer implements JsonbSerializer<HttpProblem
             generator.writeEnd();
         }
 
+        // Serialize the cause recursively
+        if (problem.getCause() != null) {
+            generator.writeKey("cause");
+            serialize(problem.getCause(), generator, ctx);
+        }
+
         generator.writeEnd();
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/openapi/problem/HttpProblemMother.java
+++ b/runtime/src/test/java/io/quarkiverse/openapi/problem/HttpProblemMother.java
@@ -35,4 +35,73 @@ public final class HttpProblemMother {
                 .withHeader("X-String-Header", "ABC");
     }
 
+    public static HttpProblem.HttpProblemBuilder singleNestedProblem() {
+
+        HttpProblem orig = HttpProblem.builder()
+                .withType(URI.create("http://tietoevry.com/problem"))
+                .withInstance(URI.create("/endpoint"))
+                .withStatus(BAD_REQUEST.getStatusCode())
+                .withTitle("Something wrong in the dirt")
+                .withDetail("Deep down wrongness, zażółć gęślą jaźń for Håkensth")
+                .withContext("custom_field_1", "too long")
+                .withContext("custom_field_2", "too short")
+                .withHeader("X-Numeric-Header", 123)
+                .withHeader("X-String-Header", "ABC")
+                .build();
+
+        return HttpProblem.builder()
+                .withType(URI.create("http://tietoevry.com/problem"))
+                .withInstance(URI.create("/endpoint"))
+                .withStatus(BAD_REQUEST.getStatusCode())
+                .withTitle("Something wrong in the dirt")
+                .withDetail("Deep down wrongness, zażółć gęślą jaźń for Håkensth")
+                .withContext("custom_field_1", "too long")
+                .withContext("custom_field_2", "too short")
+                .withHeader("X-Numeric-Header", 123)
+                .withHeader("X-String-Header", "ABC")
+                .withCause(orig);
+
+    }
+
+    public static HttpProblem.HttpProblemBuilder doubleNessProblem() {
+
+        HttpProblem orig = HttpProblem.builder()
+                .withType(URI.create("http://tietoevry.com/problem"))
+                .withInstance(URI.create("/endpoint"))
+                .withStatus(BAD_REQUEST.getStatusCode())
+                .withTitle("Something wrong in the dirt")
+                .withDetail("Deep down wrongness, zażółć gęślą jaźń for Håkensth")
+                .withContext("custom_field_1", "too long")
+                .withContext("custom_field_2", "too short")
+                .withHeader("X-Numeric-Header", 123)
+                .withHeader("X-String-Header", "ABC")
+                .build();
+
+        HttpProblem nested = HttpProblem.builder()
+                .withType(URI.create("http://tietoevry.com/problem"))
+                .withInstance(URI.create("/endpoint"))
+                .withStatus(BAD_REQUEST.getStatusCode())
+                .withTitle("Something wrong in the dirt")
+                .withDetail("Deep down wrongness, zażółć gęślą jaźń for Håkensth")
+                .withContext("custom_field_1", "too long")
+                .withContext("custom_field_2", "too short")
+                .withHeader("X-Numeric-Header", 123)
+                .withHeader("X-String-Header", "ABC")
+                .withCause(orig)
+                .build();
+
+        return HttpProblem.builder()
+                .withType(URI.create("http://tietoevry.com/problem"))
+                .withInstance(URI.create("/endpoint"))
+                .withStatus(BAD_REQUEST.getStatusCode())
+                .withTitle("Something wrong in the dirt")
+                .withDetail("Deep down wrongness, zażółć gęślą jaźń for Håkensth")
+                .withContext("custom_field_1", "too long")
+                .withContext("custom_field_2", "too short")
+                .withHeader("X-Numeric-Header", 123)
+                .withHeader("X-String-Header", "ABC")
+                .withCause(nested);
+
+    }
+
 }

--- a/runtime/src/test/java/io/quarkiverse/openapi/problem/jackson/JacksonProblemSerializerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/openapi/problem/jackson/JacksonProblemSerializerTest.java
@@ -1,6 +1,5 @@
 package io.quarkiverse.openapi.problem.jackson;
 
-import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
@@ -15,21 +14,31 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import io.quarkiverse.openapi.problem.HttpProblem;
 import io.quarkiverse.openapi.problem.HttpProblemMother;
 
 class JacksonProblemSerializerTest {
 
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    JsonGenerator jsonGenerator;
-
-    JacksonProblemSerializer serializer = new JacksonProblemSerializer();
+    private ByteArrayOutputStream outputStream;
+    private JsonGenerator jsonGenerator;
+    private JacksonProblemSerializer serializer;
+    private ObjectMapper mapper;
 
     @BeforeEach
     void setUp() throws IOException {
-        jsonGenerator = new JsonFactory()
-                .createGenerator(outputStream, JsonEncoding.UTF8);
+        outputStream = new ByteArrayOutputStream();
+        mapper = new ObjectMapper(); // Create ObjectMapper
+        jsonGenerator = new JsonFactory().createGenerator(outputStream, JsonEncoding.UTF8);
+        jsonGenerator.setCodec(mapper); // Set ObjectCodec to avoid IllegalStateException
+        serializer = new JacksonProblemSerializer();
+
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(HttpProblem.class, serializer);
+
+        mapper.registerModule(module);
     }
 
     @Test
@@ -37,10 +46,9 @@ class JacksonProblemSerializerTest {
     void shouldSerializeAllFields() throws IOException {
         HttpProblem problem = HttpProblemMother.complexProblem().build();
 
-        serializer.serialize(problem, jsonGenerator, null);
+        serializer.serialize(problem, jsonGenerator, mapper.getSerializerProvider());
 
-        assertThat(serializedProblem())
-                .isEqualTo(HttpProblemMother.SERIALIZED_COMPLEX_PROBLEM);
+        assertThat(serializedProblem()).isEqualTo(HttpProblemMother.SERIALIZED_COMPLEX_PROBLEM);
     }
 
     @Test
@@ -48,29 +56,54 @@ class JacksonProblemSerializerTest {
     void shouldSerializeOnlyNotNullFields() throws IOException {
         HttpProblem problem = HttpProblemMother.badRequestProblem();
 
-        serializer.serialize(problem, jsonGenerator, null);
+        serializer.serialize(problem, jsonGenerator, mapper.getSerializerProvider());
 
-        assertThat(serializedProblem())
-                .isEqualTo(HttpProblemMother.SERIALIZED_BAD_REQUEST_PROBLEM);
+        assertThat(serializedProblem()).isEqualTo(HttpProblemMother.SERIALIZED_BAD_REQUEST_PROBLEM);
     }
 
     @Test
-    @DisplayName("Should decode uri for instance field")
+    @DisplayName("Should decode URI for instance field")
     void shouldDecodeUriForInstanceField() throws IOException {
         HttpProblem problem = HttpProblem.builder()
-                .withStatus(NOT_FOUND.getStatusCode())
+                .withStatus(404)
                 .withInstance(URI.create("%2Fnon%7Cexisting%7Bpath+%2Fwith%7Bunwise%5Ccharacters%3E%23"))
                 .build();
 
-        serializer.serialize(problem, jsonGenerator, null);
+        serializer.serialize(problem, jsonGenerator, mapper.getSerializerProvider());
 
         assertThat(serializedProblem()).contains("""
                 "instance":"/non|existing{path /with{unwise\\\\characters>#"}""");
     }
 
-    private String serializedProblem() throws IOException {
-        jsonGenerator.close();
-        return outputStream.toString(StandardCharsets.UTF_8);
+    @Test
+    @DisplayName("Should serialize single nested cause field")
+    void shouldSerializeOnlySingleNestedProblem() throws IOException {
+        String result = """
+                {"type":"http://tietoevry.com/problem","status":400,"title":"Something wrong in the dirt","detail":"Deep down wrongness, zażółć gęślą jaźń for Håkensth","instance":"/endpoint","context":{"custom_field_1":"too long","custom_field_2":"too short"},"cause":{"type":"http://tietoevry.com/problem","status":400,"title":"Something wrong in the dirt","detail":"Deep down wrongness, zażółć gęślą jaźń for Håkensth","instance":"/endpoint","context":{"custom_field_1":"too long","custom_field_2":"too short"}}}
+                """;
+
+        HttpProblem problem = HttpProblemMother.singleNestedProblem().build();
+        serializer.serialize(problem, jsonGenerator, mapper.getSerializerProvider());
+
+        assertThat(serializedProblem().trim()).isEqualTo(result.trim());
     }
 
+    @Test
+    @DisplayName("Should serialize double nested cause field")
+    void shouldSerializeDoubleNestedProblem() throws IOException {
+        String result = """
+                {"type":"http://tietoevry.com/problem","status":400,"title":"Something wrong in the dirt","detail":"Deep down wrongness, zażółć gęślą jaźń for Håkensth","instance":"/endpoint","context":{"custom_field_1":"too long","custom_field_2":"too short"},"cause":{"type":"http://tietoevry.com/problem","status":400,"title":"Something wrong in the dirt","detail":"Deep down wrongness, zażółć gęślą jaźń for Håkensth","instance":"/endpoint","context":{"custom_field_1":"too long","custom_field_2":"too short"},"cause":{"type":"http://tietoevry.com/problem","status":400,"title":"Something wrong in the dirt","detail":"Deep down wrongness, zażółć gęślą jaźń for Håkensth","instance":"/endpoint","context":{"custom_field_1":"too long","custom_field_2":"too short"}}}}
+                """;
+
+        HttpProblem problem = HttpProblemMother.doubleNessProblem().build();
+        serializer.serialize(problem, jsonGenerator, mapper.getSerializerProvider());
+
+        assertThat(serializedProblem().trim()).isEqualTo(result.trim());
+    }
+
+    private String serializedProblem() throws IOException {
+        jsonGenerator.flush(); // Ensure all JSON is written
+        jsonGenerator.close(); // Close the stream after flushing
+        return outputStream.toString(StandardCharsets.UTF_8);
+    }
 }

--- a/runtime/src/test/java/io/quarkiverse/openapi/problem/jsonb/JsonbProblemSerializerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/openapi/problem/jsonb/JsonbProblemSerializerTest.java
@@ -70,4 +70,43 @@ class JsonbProblemSerializerTest {
         return outputStream.toString(StandardCharsets.UTF_8);
     }
 
+    @Test
+    @DisplayName("Should serialize single nested cause field")
+    void shouldSerializeOnlySingleNestedProblem() {
+
+        // Result of json conversion
+        String result = """
+                {"type":"http://tietoevry.com/problem","status":400,"title":"Something wrong in the dirt","detail":"Deep down wrongness, zażółć gęślą jaźń for Håkensth","instance":"/endpoint","context":{"custom_field_1":"too long","custom_field_2":"too short"},"cause":{"type":"http://tietoevry.com/problem","status":400,"title":"Something wrong in the dirt","detail":"Deep down wrongness, zażółć gęślą jaźń for Håkensth","instance":"/endpoint","context":{"custom_field_1":"too long","custom_field_2":"too short"}}}
+                """;
+
+        // Get the HttpProblem to test
+        HttpProblem problem = HttpProblemMother.singleNestedProblem().build();
+
+        // Serialize
+        serializer.serialize(problem, jsonGenerator, context);
+
+        // Compare results
+        assertThat(serializedProblem().trim())
+                .isEqualTo(result.trim());
+    }
+
+    @Test
+    @DisplayName("Should serialize double nested cause field")
+    void shouldSerializeDoubleNestedProblem() {
+
+        // Result of json conversion
+        String result = """
+                {"type":"http://tietoevry.com/problem","status":400,"title":"Something wrong in the dirt","detail":"Deep down wrongness, zażółć gęślą jaźń for Håkensth","instance":"/endpoint","context":{"custom_field_1":"too long","custom_field_2":"too short"},"cause":{"type":"http://tietoevry.com/problem","status":400,"title":"Something wrong in the dirt","detail":"Deep down wrongness, zażółć gęślą jaźń for Håkensth","instance":"/endpoint","context":{"custom_field_1":"too long","custom_field_2":"too short"},"cause":{"type":"http://tietoevry.com/problem","status":400,"title":"Something wrong in the dirt","detail":"Deep down wrongness, zażółć gęślą jaźń for Håkensth","instance":"/endpoint","context":{"custom_field_1":"too long","custom_field_2":"too short"}}}}
+                """;
+
+        // Get the HttpProblem to test
+        HttpProblem problem = HttpProblemMother.doubleNessProblem().build();
+
+        // Serialize
+        serializer.serialize(problem, jsonGenerator, context);
+
+        // Compare results
+        assertThat(serializedProblem().trim())
+                .isEqualTo(result.trim());
+    }
 }


### PR DESCRIPTION
Adds a new `cause` element which can be used to hold the original message from downstream and rethrow from the receiving client.